### PR TITLE
Refactor variables into static member variables

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,8 +4,9 @@ root = true
 [*.cs]
 dotnet_analyzer_diagnostic.category-Style.severity = suggestion
 
-# Disable var warning
+# Disable var and s_ prefix warning
 dotnet_diagnostic.IDE0008.severity = none
+dotnet_diagnostic.IDE1006.severity = none
 
 ########### DEFAULTS (dotnet new editorconfig)
 

--- a/unity/CAVE/Assets/W3D_Translator/CLI.cs
+++ b/unity/CAVE/Assets/W3D_Translator/CLI.cs
@@ -29,10 +29,9 @@ namespace W3D
     {
         private void Start() { Main(); } // TEMP: Execute script from Unity directly
 
-#pragma warning disable IDE1006
-        private static Story xml;
-        private static GameObject story;
-        private static readonly Dictionary<string, (GameObject, Object)> gameObjects = new();
+        private static Story XML;
+        private static GameObject Story;
+        private static readonly Dictionary<string, (GameObject, Object)> GameObjects = new();
 
         public static void Main()
         {
@@ -49,11 +48,11 @@ namespace W3D
             // GameObject xrRig = instantiatedScene.scene.GetRootGameObjects()[0];
             // story = instantiatedScene.scene.GetRootGameObjects()[1];
             GameObject xrRig = SceneManager.GetActiveScene().GetRootGameObjects()[0];
-            story = SceneManager.GetActiveScene().GetRootGameObjects()[1];
+            Story = SceneManager.GetActiveScene().GetRootGameObjects()[1];
 
-            ApplyGlobalSettings(xml.Global, xrRig);
-            BuildWalls(story.transform);
-            TranslateGameObjects(xml.ObjectRoot);
+            ApplyGlobalSettings(XML.Global, xrRig);
+            BuildWalls(Story.transform);
+            TranslateGameObjects(XML.ObjectRoot);
 
             // TODO (95): Generate the <Group>s
             // TODO (96): Generate the <Timeline>s
@@ -96,7 +95,7 @@ namespace W3D
             {
                 XmlSerializer serializer = new(typeof(Story));
                 using XmlReader reader = XmlReader.Create(xmlPath);
-                xml = (Story)serializer.Deserialize(reader);
+                XML = (Story)serializer.Deserialize(reader);
             }
             catch (FileNotFoundException e)
             {
@@ -133,7 +132,7 @@ namespace W3D
         private static void ApplyGlobalSettings(Global xml, GameObject xrRig)
         {
             Transform mainCameraT = xrRig.transform.Find("Camera Offset").Find("Main Camera");
-            Transform caveCameraT = story.transform.Find("Cave Camera");
+            Transform caveCameraT = Story.transform.Find("Cave Camera");
 
             // Load default lighting settings and delete skybox
             Lightmapping.lightingSettings = Resources.Load<LightingSettings>("CAVE");
@@ -148,7 +147,7 @@ namespace W3D
             UnityEngine.Camera caveCamera =
                 caveCameraT.GetComponent<UnityEngine.Camera>();
             caveCamera.farClipPlane = xmlCaveCamera.FarClip;
-            xmlCaveCamera.Placement.SetTransform(caveCamera.transform, Vector3.one, story.transform);
+            xmlCaveCamera.Placement.SetTransform(caveCamera.transform, Vector3.one, Story.transform);
 
             // Update Camera inside of xrRig
             Camera xmlCamera = xml.Camera;
@@ -193,7 +192,7 @@ namespace W3D
             new Vector3(-4, -4, 0),
         };
 
-            foreach (Placement placement in xml.PlacementRoot)
+            foreach (Placement placement in XML.PlacementRoot)
             {
                 // Objects in the "Center" space are nested directly under Story
                 if (placement.Name == "Center") { continue; }
@@ -219,7 +218,7 @@ namespace W3D
         }
 
         // Convert Story.ObjectRoot to a dictionary of {name: GameObject} pairs
-        private static void TranslateGameObjects(List<W3D.Object> objectList)
+        private static void TranslateGameObjects(List<Object> objectList)
         {
             /** Object
                 name: gameObject.name
@@ -230,7 +229,7 @@ namespace W3D
                 AroundSelfAxis: TODO (76)
                 Scale: gameObject.localScale (set in Placement.SetTransform)
             */
-            foreach (W3D.Object xml in objectList)
+            foreach (Object xml in objectList)
             {
                 GameObject contentGO = xml.Content.Create(xml);
                 if (xml.LinkRoot is not null)
@@ -242,7 +241,7 @@ namespace W3D
                     // Set xml for canvas
                     prefab.name = xml.Name;
                     prefab.SetActive(xml.Visible);
-                    xml.Placement.SetTransform(prefab.transform, xml.GetScale(), story.transform);
+                    xml.Placement.SetTransform(prefab.transform, xml.GetScale(), Story.transform);
                     prefab.transform.localScale *= 0.1f;
 
                     Link link = xml.LinkRoot.Link;
@@ -259,19 +258,19 @@ namespace W3D
                 else
                 {
                     contentGO.SetActive(xml.Visible);
-                    xml.Placement.SetTransform(contentGO.transform, xml.GetScale(), story.transform);
+                    xml.Placement.SetTransform(contentGO.transform, xml.GetScale(), Story.transform);
                 }
-                gameObjects.Add(contentGO.name, (contentGO, xml));
+                GameObjects.Add(contentGO.name, (contentGO, xml));
             }
             return;
         }
 
         private static void SetLinkActions()
         {
-            ActionMethods methods = story.GetComponent<ActionMethods>();
+            ActionMethods methods = Story.GetComponent<ActionMethods>();
 
             foreach (KeyValuePair<string, (GameObject, Object)> pair in
-                gameObjects.Where(pair => pair.Value.Item2.LinkRoot is not null)
+                GameObjects.Where(pair => pair.Value.Item2.LinkRoot is not null)
             )
             {
                 (GameObject go, Object obj) = pair.Value;

--- a/unity/CAVE/Assets/W3D_Translator/CLI.cs
+++ b/unity/CAVE/Assets/W3D_Translator/CLI.cs
@@ -33,9 +33,9 @@ namespace W3D
         private void Start() { Main(); } // TEMP: Execute script from Unity directly
 
 #pragma warning disable IDE1006
-    private static Story xml;
-    private static GameObject story;
-    private static readonly ObjDictionary gameObjects = new();
+        private static Story xml;
+        private static GameObject story;
+        private static readonly ObjDictionary gameObjects = new();
 
         public static void Main()
         {
@@ -64,7 +64,7 @@ namespace W3D
             // TODO (98): Generate the <Event>s
             // TODO (99): Generate the <ParticleAction>s
 
-        SetLinkActions();
+            SetLinkActions();
 
             // Save and quit
             // EditorSceneManager.SaveScene(EditorSceneManager.GetActiveScene());
@@ -134,11 +134,11 @@ namespace W3D
             }
         }
 
-    // Apply camera, lighting, and tracking settings from the xml
-    private static void ApplyGlobalSettings(Global xml, GameObject xrRig)
-    {
-        Transform mainCameraT = xrRig.transform.Find("Camera Offset").Find("Main Camera");
-        Transform caveCameraT = story.transform.Find("Cave Camera");
+        // Apply camera, lighting, and tracking settings from the xml
+        private static void ApplyGlobalSettings(Global xml, GameObject xrRig)
+        {
+            Transform mainCameraT = xrRig.transform.Find("Camera Offset").Find("Main Camera");
+            Transform caveCameraT = story.transform.Find("Cave Camera");
 
             // Load default lighting settings and delete skybox
             Lightmapping.lightingSettings = Resources.Load<LightingSettings>("CAVE");
@@ -187,11 +187,11 @@ namespace W3D
             }
         }
 
-    // Create each <Placement> as an outlined GameObject 
-    private static void BuildWalls(Transform storyT)
-    {
-        // Each wall is an 8" by 8" square
-        Vector3[] points = {
+        // Create each <Placement> as an outlined GameObject 
+        private static void BuildWalls(Transform storyT)
+        {
+            // Each wall is an 8" by 8" square
+            Vector3[] points = {
             new Vector3(-4, 4, 0),
             new Vector3(4, 4, 0),
             new Vector3(4, -4, 0),
@@ -223,26 +223,26 @@ namespace W3D
             return;
         }
 
-    // Convert Story.ObjectRoot to a dictionary of {name: GameObject} pairs
-    private static void TranslateGameObjects(List<W3D.Object> objectList)
-    {
-        /** Object
-            name: gameObject.name
-            Visible: gameObject.active
-            Color: gameObject.[content].color (disabledColor if <LinkRoot> is present)
-            Lighting: TODO (76)
-            ClickThrough: TODO (76)
-            AroundSelfAxis: TODO (76)
-            Scale: gameObject.localScale (set in Placement.SetTransform)
-        */
-        foreach (W3D.Object xml in objectList)
+        // Convert Story.ObjectRoot to a dictionary of {name: GameObject} pairs
+        private static void TranslateGameObjects(List<W3D.Object> objectList)
         {
-            GameObject contentGO = xml.Content.Create(xml);
-            if (xml.LinkRoot is not null)
+            /** Object
+                name: gameObject.name
+                Visible: gameObject.active
+                Color: gameObject.[content].color (disabledColor if <LinkRoot> is present)
+                Lighting: TODO (76)
+                ClickThrough: TODO (76)
+                AroundSelfAxis: TODO (76)
+                Scale: gameObject.localScale (set in Placement.SetTransform)
+            */
+            foreach (W3D.Object xml in objectList)
             {
-                // Instantiate a new link prefab
-                GameObject prefab = Instantiate(Resources.Load<GameObject>("Prefabs/canvas"));
-                prefab.GetComponent<Canvas>().worldCamera = UnityEngine.Camera.main;
+                GameObject contentGO = xml.Content.Create(xml);
+                if (xml.LinkRoot is not null)
+                {
+                    // Instantiate a new link prefab
+                    GameObject prefab = Instantiate(Resources.Load<GameObject>("Prefabs/canvas"));
+                    prefab.GetComponent<Canvas>().worldCamera = UnityEngine.Camera.main;
 
                     // Set xml for canvas
                     prefab.name = xml.Name;
@@ -268,10 +268,10 @@ namespace W3D
                 }
                 gameObjects.Add(contentGO.name, (contentGO, xml));
             }
-            return gameObjects;
+            return;
         }
 
-        private static void SetLinkActions(ObjDictionary gameObjects, GameObject story)
+        private static void SetLinkActions()
         {
             ActionMethods methods = story.GetComponent<ActionMethods>();
 

--- a/unity/CAVE/Assets/W3D_Translator/CLI.cs
+++ b/unity/CAVE/Assets/W3D_Translator/CLI.cs
@@ -90,25 +90,23 @@ namespace W3D
         }
 
         // Deserialize the xml file into a Story object
-        private static Story LoadStory(string xmlPath)
+        private static void LoadStory(string xmlPath)
         {
             try
             {
                 XmlSerializer serializer = new(typeof(Story));
                 using XmlReader reader = XmlReader.Create(xmlPath);
-                return (Story)serializer.Deserialize(reader);
+                xml = (Story)serializer.Deserialize(reader);
             }
             catch (FileNotFoundException e)
             {
                 Debug.LogError($"ERROR: File at {xmlPath} not found");
                 Debug.LogException(e);
-                return null;
             }
             catch (Exception e)
             {
                 Debug.LogError($"Error: Deserialization of file at {xmlPath} failed.");
                 Debug.LogException(e);
-                return null;
             }
         }
 

--- a/unity/CAVE/Assets/W3D_Translator/CLI.cs
+++ b/unity/CAVE/Assets/W3D_Translator/CLI.cs
@@ -16,9 +16,6 @@ using UnityEngine.Events;
 using Unity.XR.CoreUtils;
 
 // Custom Type renaming
-// TODO (100): Should the GameObject just be a property of Object?
-using ObjDictionary = System.Collections.Generic.Dictionary
-    <string, (UnityEngine.GameObject, W3D.Object)>;
 using TType = UnityEngine.SpatialTracking.TrackedPoseDriver.TrackingType;
 
 // TODO (80): Should ConvertVector3 invert z axis always?
@@ -35,7 +32,7 @@ namespace W3D
 #pragma warning disable IDE1006
         private static Story xml;
         private static GameObject story;
-        private static readonly ObjDictionary gameObjects = new();
+        private static readonly Dictionary<string, (GameObject, Object)> gameObjects = new();
 
         public static void Main()
         {
@@ -279,8 +276,7 @@ namespace W3D
                 gameObjects.Where(pair => pair.Value.Item2.LinkRoot is not null)
             )
             {
-                // (GameObject go, Object obj) = pair.Value;
-                var (go, obj) = pair.Value;
+                (GameObject go, Object obj) = pair.Value;
                 GameObject buttonGO = go.transform.parent.gameObject;
                 Button button = buttonGO.GetComponent<Button>();
                 Link link = obj.LinkRoot.Link;

--- a/unity/CAVE/Assets/W3D_Translator/CLI.cs
+++ b/unity/CAVE/Assets/W3D_Translator/CLI.cs
@@ -30,7 +30,7 @@ public class CLI : MonoBehaviour // TEMP: MonoBehavior can be removed?
 #pragma warning disable IDE1006
     private static Story xml;
     private static GameObject story;
-    private static ObjDictionary gameObjects = new();
+    private static readonly ObjDictionary gameObjects = new();
 
     public static void Main()
     {


### PR DESCRIPTION
There's a few variables I'm creating and passing into a bunch of the CLI functions, finding it easier to just save them as member static variables of the CLI class. Also cuts down some of the type definition bloat

- `Story`
- `XML`
- `GameObjects`