### PR TITLE
Refactor Object class (?)

### DIFF
--- a/unity/CAVE/Assets/Resources/Materials/Fonts/Courier SDF.asset
+++ b/unity/CAVE/Assets/Resources/Materials/Fonts/Courier SDF.asset
@@ -70,9 +70,9 @@ Material:
     - _OutlineWidth: 0
     - _PerspectiveFilter: 0.875
     - _Reflectivity: 10
-    - _ScaleRatioA: 1
-    - _ScaleRatioB: 1
-    - _ScaleRatioC: 1
+    - _ScaleRatioA: 0.8333333
+    - _ScaleRatioB: 0.6770833
+    - _ScaleRatioC: 0.6770833
     - _ScaleX: 1
     - _ScaleY: 1
     - _ShaderFlags: 0

--- a/unity/CAVE/Assets/W3D_Translator/CLI.cs
+++ b/unity/CAVE/Assets/W3D_Translator/CLI.cs
@@ -46,7 +46,7 @@ public class CLI : MonoBehaviour // TEMP: MonoBehavior can be removed?
 
         ApplyGlobalSettings(xml.Global, xrRig, story);
         BuildWalls(xml, story.transform);
-        ObjDictionary gameObjects = TranslateGameObjects(xml.ObjectRoot, story);
+        Dictionary<string, W3D.Object> gameObjects = TranslateGameObjects(xml.ObjectRoot, story);
 
         // TODO (95): Generate the <Group>s
         // TODO (96): Generate the <Timeline>s
@@ -214,9 +214,9 @@ public class CLI : MonoBehaviour // TEMP: MonoBehavior can be removed?
     }
 
     // Convert Story.ObjectRoot to a dictionary of {name: GameObject} pairs
-    private static ObjDictionary TranslateGameObjects(List<W3D.Object> objectList, GameObject story)
+    private static Dictionary<string, W3D.Object> TranslateGameObjects(List<W3D.Object> objectList, GameObject story)
     {
-        ObjDictionary gameObjects = new();
+        Dictionary<string, W3D.Object> gameObjects = new();
         /** Object
             name: gameObject.name
             Visible: gameObject.active
@@ -257,21 +257,22 @@ public class CLI : MonoBehaviour // TEMP: MonoBehavior can be removed?
                 contentGO.SetActive(xml.Visible);
                 xml.Placement.SetTransform(contentGO.transform, xml.GetScale(), story.transform);
             }
-            gameObjects.Add(contentGO.name, (contentGO, xml));
+            xml.GameObject = contentGO;
+            gameObjects.Add(contentGO.name, xml);
         }
         return gameObjects;
     }
 
-    private static void SetLinkActions(ObjDictionary gameObjects, GameObject story)
+    private static void SetLinkActions(Dictionary<string, W3D.Object> gameObjects, GameObject story)
     {
         ActionMethods methods = story.GetComponent<ActionMethods>();
 
-        foreach (KeyValuePair<string, (GameObject, W3D.Object)> pair in
-            gameObjects.Where(pair => pair.Value.Item2.LinkRoot is not null)
+        foreach (KeyValuePair<string, W3D.Object> pair in
+            gameObjects.Where(pair => pair.Value.LinkRoot is not null)
         )
         {
-            (GameObject go, W3D.Object obj) = pair.Value;
-            GameObject buttonGO = go.transform.parent.gameObject;
+            W3D.Object obj = pair.Value;
+            GameObject buttonGO = obj.GameObject.transform.parent.gameObject;
             Button button = buttonGO.GetComponent<Button>();
             Link link = obj.LinkRoot.Link;
 
@@ -330,7 +331,3 @@ public class CLI : MonoBehaviour // TEMP: MonoBehavior can be removed?
         Console.WriteLine($"LOG:{logString}");
     }
 }
-
-// Custom Dictionary Type
-// TODO (100): Should the GameObject just be a property of W3D.Object?
-public class ObjDictionary : Dictionary<string, (GameObject, W3D.Object)> { }

--- a/unity/CAVE/Assets/W3D_Translator/CLI.cs
+++ b/unity/CAVE/Assets/W3D_Translator/CLI.cs
@@ -31,7 +31,7 @@ namespace W3D
 
         private static Story XML;
         private static GameObject Story;
-        private static readonly Dictionary<string, (GameObject, Object)> GameObjects = new();
+        private static readonly Dictionary<string, Object> GameObjects = new();
 
         public static void Main()
         {
@@ -261,7 +261,7 @@ namespace W3D
                     xml.Placement.SetTransform(contentGO.transform, xml.GetScale(), Story.transform);
                 }
                 xml.GameObject = contentGO;
-                GameObjects.Add(contentGO.name, xml);
+                GameObjects.Add(xml.Name, xml);
             }
             return;
         }

--- a/unity/CAVE/Assets/W3D_Translator/Classes.cs
+++ b/unity/CAVE/Assets/W3D_Translator/Classes.cs
@@ -141,6 +141,9 @@ namespace W3D
         [XmlText]
         public string Text;
 
+        [XmlIgnore]
+        public GameObject GameObject;
+
         public Vector3 GetScale() { return Vector3.one * Scale; }
     }
 


### PR DESCRIPTION
This was an easy change so I made it but I'm not really sure it's the right move. I add in the Unity `GameObject` as a property of the `Object` class. This would be repeated for Sound, Timeline, EventTrigger, etc.

The thing I'm not so sure about is that right now everything in regards to Unity is inside `CLI.cs` and everything in regards to the xml is in `Classes.cs`. This eliminates the need for dictionaries but starts mixing the two Unity and xml inside `Classes.cs` so I'm not really sure it's the best thing to do. 

I would appreciate everyone's input on this! Happy to here any and all opinions 😄 