### PR TITLE
Add XR Device Simulator to the scene

### DIFF
--- a/test/sample.xml
+++ b/test/sample.xml
@@ -295,6 +295,6 @@
             </Placement>
         </CaveCameraPos>
         <Background color="0, 0, 0" />
-        <WandNavigation allow-rotation="false" allow-movement="false" />
+        <WandNavigation allow-rotation="true" allow-movement="true" />
     </Global>
 </Story>

--- a/unity/CAVE/Assets/Editor/CLI.cs
+++ b/unity/CAVE/Assets/Editor/CLI.cs
@@ -47,6 +47,20 @@ namespace Writing3D
                 Root = instantiatedScene.scene.GetRootGameObjects()[1];
                 GameObjects = new Dictionary<string, (GameObject, Xml.Object)>();
 
+                if (!UnityEditorInternal.InternalEditorUtility.inBatchMode)
+                {
+                    // Testing - Instantiate the device simulator and set at top of hierarchy
+                    UnityEngine.Object.Instantiate(
+                        AssetDatabase.LoadAssetAtPath(
+                            "Assets/XR Interaction Toolkit/XR Device Simulator/" +
+                            "XR Device Simulator.prefab",
+                            typeof(GameObject)
+                        ) as GameObject,
+                        XrRig.transform.position,
+                        XrRig.transform.rotation
+                    ).transform.SetAsFirstSibling();
+                }
+
                 ApplyGlobalSettings();
                 BuildWalls();
                 TranslateGameObjects();

--- a/unity/CAVE/Assets/Resources/Textures.meta
+++ b/unity/CAVE/Assets/Resources/Textures.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: a14e28793c0619c4ca855a81bc24c7d5
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/unity/CAVE/Assets/XR/Settings/Open XR Package Settings.asset
+++ b/unity/CAVE/Assets/XR/Settings/Open XR Package Settings.asset
@@ -175,7 +175,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: feeef8d85de8db242bdda70cc7ff5acd, type: 3}
   m_Name: OculusTouchControllerProfile WSA
   m_EditorClassIdentifier: 
-  m_enabled: 0
+  m_enabled: 1
   nameUi: Oculus Touch Controller Profile
   version: 0.0.1
   featureIdInternal: com.unity.openxr.feature.input.oculustouch
@@ -289,7 +289,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: feeef8d85de8db242bdda70cc7ff5acd, type: 3}
   m_Name: OculusTouchControllerProfile Standalone
   m_EditorClassIdentifier: 
-  m_enabled: 0
+  m_enabled: 1
   nameUi: Oculus Touch Controller Profile
   version: 0.0.1
   featureIdInternal: com.unity.openxr.feature.input.oculustouch

--- a/unity/CAVE/Assets/XR/XRGeneralSettings.asset
+++ b/unity/CAVE/Assets/XR/XRGeneralSettings.asset
@@ -74,6 +74,20 @@ MonoBehaviour:
   m_AutomaticLoading: 0
   m_AutomaticRunning: 0
   m_Loaders: []
+--- !u!114 &-4426428139925521947
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d236b7d11115f2143951f1e14045df39, type: 3}
+  m_Name: WebGL Settings
+  m_EditorClassIdentifier: 
+  m_LoaderManagerInstance: {fileID: 1030621021723241308}
+  m_InitManagerOnStart: 1
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -86,12 +100,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d2dc886499c26824283350fa532d087d, type: 3}
   m_Name: XRGeneralSettings
   m_EditorClassIdentifier: 
-  Keys: 01000000070000001c00000004000000
+  Keys: 01000000070000001c000000040000000d0000000e000000
   Values:
   - {fileID: -6517218471499782410}
   - {fileID: -8196854396901781169}
   - {fileID: 332800863423338148}
   - {fileID: -6546576050900071261}
+  - {fileID: -4426428139925521947}
+  - {fileID: 4081908138857436821}
 --- !u!114 &332800863423338148
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -106,6 +122,39 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_LoaderManagerInstance: {fileID: 4897379186331661704}
   m_InitManagerOnStart: 1
+--- !u!114 &1030621021723241308
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4c3631f5e58749a59194e0cf6baf6d5, type: 3}
+  m_Name: WebGL Providers
+  m_EditorClassIdentifier: 
+  m_RequiresSettingsUpdate: 0
+  m_AutomaticLoading: 0
+  m_AutomaticRunning: 0
+  m_Loaders: []
+--- !u!114 &1587509760174322493
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4c3631f5e58749a59194e0cf6baf6d5, type: 3}
+  m_Name: WSA Providers
+  m_EditorClassIdentifier: 
+  m_RequiresSettingsUpdate: 0
+  m_AutomaticLoading: 0
+  m_AutomaticRunning: 0
+  m_Loaders:
+  - {fileID: 11400000, guid: 28fe04729daeb2345bebc951fad25769, type: 2}
 --- !u!114 &3428388118024481725
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -123,6 +172,20 @@ MonoBehaviour:
   m_AutomaticRunning: 0
   m_Loaders:
   - {fileID: 11400000, guid: 28fe04729daeb2345bebc951fad25769, type: 2}
+--- !u!114 &4081908138857436821
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d236b7d11115f2143951f1e14045df39, type: 3}
+  m_Name: WSA Settings
+  m_EditorClassIdentifier: 
+  m_LoaderManagerInstance: {fileID: 1587509760174322493}
+  m_InitManagerOnStart: 1
 --- !u!114 &4897379186331661704
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/unity/CAVE/Packages/manifest.json
+++ b/unity/CAVE/Packages/manifest.json
@@ -14,6 +14,7 @@
     "com.unity.visualscripting": "1.7.8",
     "com.unity.xr.interaction.toolkit": "2.0.2",
     "com.unity.xr.management": "4.2.1",
+    "com.unity.xr.openxr": "1.4.2",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/unity/CAVE/Packages/packages-lock.json
+++ b/unity/CAVE/Packages/packages-lock.json
@@ -250,7 +250,7 @@
     },
     "com.unity.xr.openxr": {
       "version": "1.4.2",
-      "depth": 1,
+      "depth": 0,
       "source": "registry",
       "dependencies": {
         "com.unity.xr.management": "4.0.1",


### PR DESCRIPTION
Adds the XR Device Simulator prefab to the scene when I'm not running Unity from batch mode (aka from the GUI). This lets me test things out without having to put the headset on all the time but without making permanent changes to the CAVE scene.

Right now only the controllers work which is a known bug. Totally okay for my workflow right now because the controllers still work - I can press the buttons and do all the things I need to do still

 Added issue #119 for a future fix