### PR TITLE
Add data for `Move` and `RelativeMove` transitions

### DIFF
--- a/unity/CAVE/Assets/Editor/CLI.cs
+++ b/unity/CAVE/Assets/Editor/CLI.cs
@@ -6,7 +6,6 @@ using UnityEditor;
 using UnityEditor.SceneTemplate;
 using UnityEngine;
 using UnityEngine.SpatialTracking;
-using UnityEngine.UI;
 using UnityEngine.Events;
 using Unity.XR.CoreUtils;
 
@@ -191,7 +190,7 @@ namespace Writing3D
             // Create each <Placement> as an outlined GameObject 
             private static void BuildWalls()
             {
-                foreach (Placement xmlPlacement in XmlRoot.PlacementRoot)
+                foreach (Xml.Placement xmlPlacement in XmlRoot.PlacementRoot)
                 {
                     // Objects in the "Center" space are nested directly under Root
                     if (xmlPlacement.Name == "Center") { continue; }

--- a/unity/CAVE/Assets/Editor/CLI_Helpers.cs
+++ b/unity/CAVE/Assets/Editor/CLI_Helpers.cs
@@ -239,23 +239,22 @@ namespace Writing3D
                         );
                         break;
                     case GroupChange xmlAction:
-                        // TODO 87:
+                        // TODO 87
                         break;
                     case TimerChange xmlAction:
-                        // TODO 88:
+                        // TODO 88
                         break;
                     case SoundChange xmlAction:
-                        // TODO 91:
+                        // TODO 91
                         break;
                     case EventChange xmlAction:
-                        // TODO 89:
+                        // TODO 89
                         break;
                     case MoveCave xmlAction:
-                        // TODO 90:
+                        // TODO 90
                         break;
-
                     case null:
-                        // TODO 92: (Restart)
+                        // TODO 92: Restart
                         break;
                     default:
                         throw new Exception("Invalid action type");

--- a/unity/CAVE/Assets/Editor/CLI_Helpers.cs
+++ b/unity/CAVE/Assets/Editor/CLI_Helpers.cs
@@ -69,7 +69,6 @@ namespace Writing3D
                 gameObjectT.localScale = ConvertScale(scale);
                 gameObjectT.SetParent(GetParent(xmlPlacement), false);
                 gameObjectT.localPosition = ConvertVector3(xmlPlacement.PositionString);
-
                 switch (xmlPlacement.Rotation)
                 {
                     case Axis xmlAxis:

--- a/unity/CAVE/Assets/Editor/CLI_Helpers.cs
+++ b/unity/CAVE/Assets/Editor/CLI_Helpers.cs
@@ -116,26 +116,25 @@ namespace Writing3D
                 {
                     case Axis xmlAxis:
                         placement.RotationType = Placement.Type.Euler;
-                        placement.Rotation = CreateEuler(xmlAxis.RotationString, xmlAxis.Angle);
+                        placement.EulerRotation =
+                            CreateEuler(xmlAxis.RotationString, xmlAxis.Angle);
                         break;
                     case LookAt xmlLookAt:
                         placement.RotationType = Placement.Type.LookAt;
-                        placement.Rotation = new Placement.LookAtRotation(
+                        placement.LookRotation = new Placement.LookAtRotation(
                             ConvertVector3(xmlLookAt.TargetString),
                             ConvertVector3(xmlLookAt.UpString)
                         );
                         break;
                     case Normal xmlNormal:
                         placement.RotationType = Placement.Type.Euler;
-                        placement.Rotation = CreateEuler(xmlNormal.NormalString, xmlNormal.Angle);
+                        placement.EulerRotation =
+                            CreateEuler(xmlNormal.NormalString, xmlNormal.Angle);
                         break;
                     default:
                         placement.RotationType = Placement.Type.None;
                         break;
                 }
-
-
-
                 return placement;
             }
 

--- a/unity/CAVE/Assets/Editor/CLI_Helpers.cs
+++ b/unity/CAVE/Assets/Editor/CLI_Helpers.cs
@@ -124,13 +124,6 @@ namespace Writing3D
                             ConvertVector3(xmlLookAt.TargetString),
                             ConvertVector3(xmlLookAt.UpString)
                         );
-
-                        // TODO: placement.Rotation as LookAtRotation
-                        // gameObjectT.rotation = Quaternion.LookRotation(
-                        //     gameObjectT.position -
-                        //         Root.transform.TransformPoint(ConvertVector3(xmlLookAt.TargetString)),
-                        //     ConvertVector3(xmlLookAt.UpString)
-                        // );
                         break;
                     case Normal xmlNormal:
                         placement.RotationType = Placement.Type.Euler;
@@ -278,12 +271,13 @@ namespace Writing3D
 
             public static Transitions.Transition GetTransition(Xml.Transition xmlTransition, float duration)
             {
-                // TODO 122: Init for Move and RelativeMove
                 return xmlTransition.Change switch
                 {
                     bool visible => CreateInstance<Visible>().Init(visible, duration),
-                    MovementTransition placement => CreateInstance<Move>(),
-                    MoveRel placement => CreateInstance<RelativeMove>(),
+                    MovementTransition move => CreateInstance<Move>()
+                        .Init(GetPlacement(move.Placement), duration),
+                    MoveRel move => CreateInstance<RelativeMove>()
+                        .Init(GetPlacement(move.Placement), duration),
                     string color => CreateInstance<Transitions.Color>()
                         .Init(ConvertColor(color), duration),
                     float scale => CreateInstance<Scale>().Init(scale),

--- a/unity/CAVE/Assets/Resources/Scripts/ObjectManager.cs
+++ b/unity/CAVE/Assets/Resources/Scripts/ObjectManager.cs
@@ -34,14 +34,14 @@ namespace Writing3D
         {
             // Update parent
             // MoveTowards && RotateTowards in local space (parent space?)
-            Move moveT = (Move)transition;
-            Debug.Log($"MoveT {gameObject.name}");
+            Placement placement = (transition as Move)?.Placement;
+            Debug.Log($"RelativeMoveT {gameObject.name} {placement.Parent.name} {placement.Position}");
         }
 
         public void RelativeMoveTransition(Transition transition)
         {
-            RelativeMove relativeMoveT = (RelativeMove)transition;
-            Debug.Log($"RelativeMoveT {gameObject.name}");
+            Placement placement = (transition as RelativeMove)?.Placement;
+            Debug.Log($"RelativeMoveT {gameObject.name} {placement.Parent.name} {placement.Position}");
         }
 
         public void ColorTransition(Transition transition)

--- a/unity/CAVE/Assets/Resources/Scripts/ObjectManager.cs
+++ b/unity/CAVE/Assets/Resources/Scripts/ObjectManager.cs
@@ -32,6 +32,8 @@ namespace Writing3D
 
         public void MoveTransition(Transition transition)
         {
+            // Update parent
+            // MoveTowards && RotateTowards in local space (parent space?)
             Move moveT = (Move)transition;
             Debug.Log($"MoveT {gameObject.name}");
         }

--- a/unity/CAVE/Assets/Resources/Scripts/SceneManager.cs
+++ b/unity/CAVE/Assets/Resources/Scripts/SceneManager.cs
@@ -1,3 +1,5 @@
+using System;
+
 using UnityEngine;
 
 namespace Writing3D
@@ -8,6 +10,42 @@ namespace Writing3D
         {
             // Quit when "ESC" is pressed
             if (Input.GetKeyDown(KeyCode.Escape)) { Application.Quit(); }
+        }
+    }
+
+    [Serializable]
+    public class Placement
+    {
+        public Transform Parent;
+        public Vector3 Position;
+        public object Rotation; // Euler (Type.Euler) or LookAtRotation (Type.LookAt)
+
+        public Type RotationType;
+
+        public Placement(Transform parent, Vector3 position)
+        {
+            Parent = parent;
+            Position = position;
+        }
+
+        public enum Type
+        {
+            None,
+            Euler,
+            LookAt
+        }
+
+        [Serializable]
+        public class LookAtRotation
+        {
+            public Vector3 Target;
+            public Vector3 Up;
+
+            public LookAtRotation(Vector3 target, Vector3 up)
+            {
+                Target = target;
+                Up = up;
+            }
         }
     }
 }

--- a/unity/CAVE/Assets/Resources/Scripts/SceneManager.cs
+++ b/unity/CAVE/Assets/Resources/Scripts/SceneManager.cs
@@ -16,6 +16,7 @@ namespace Writing3D
     [Serializable]
     public class Placement
     {
+        // TODO: GUI should change Rot
         public Transform Parent;
         public Vector3 Position;
         public object Rotation; // Euler (Type.Euler) or LookAtRotation (Type.LookAt)

--- a/unity/CAVE/Assets/Resources/Scripts/SceneManager.cs
+++ b/unity/CAVE/Assets/Resources/Scripts/SceneManager.cs
@@ -16,12 +16,12 @@ namespace Writing3D
     [Serializable]
     public class Placement
     {
-        // TODO: GUI should change Rot
+        // TODO 128: GUI should change Euler/Look Rotation based on Type
         public Transform Parent;
         public Vector3 Position;
-        public object Rotation; // Euler (Type.Euler) or LookAtRotation (Type.LookAt)
-
         public Type RotationType;
+        public Vector3 EulerRotation; // (Type.Euler)
+        public LookAtRotation LookRotation; //(Type.LookAt)        
 
         public Placement(Transform parent, Vector3 position)
         {

--- a/unity/CAVE/Assets/Resources/Scripts/Transitions/Move.cs
+++ b/unity/CAVE/Assets/Resources/Scripts/Transitions/Move.cs
@@ -14,16 +14,11 @@ namespace Writing3D
         [Serializable]
         public class Move : Transition
         {
-            public Transform Parent;
-            public Vector3 LocalPosition;
-            public Quaternion LocalRotation;
-            // TODO 122: Data and logic for MoveTransition
+            public Placement Placement;
 
-            public Move Init(Transform parent, Vector3 localPosition, Quaternion localRotation, float duration)
+            public Move Init(Placement placement, float duration)
             {
-                Parent = parent;
-                LocalPosition = localPosition;
-                LocalRotation = localRotation;
+                Placement = placement;
                 Duration = duration;
                 return this;
             }

--- a/unity/CAVE/Assets/Resources/Scripts/Transitions/RelativeMove.cs
+++ b/unity/CAVE/Assets/Resources/Scripts/Transitions/RelativeMove.cs
@@ -12,9 +12,6 @@ namespace Writing3D
             order = 3
         )]
         [Serializable]
-        public class RelativeMove : Move
-        {
-            // TODO 122: Data and logic for RelativeMoveTransition
-        }
+        public class RelativeMove : Move { }
     }
 }


### PR DESCRIPTION
- Adds the `Placement` class in Unity which contains a (local) position, rotation (local euler or "look at"), and the transform of the new parent
-  Refactors switch statements to throw an exception on default when there's no other possibility
- Updates `ObjectManager.cs` functions to log information about the Placement class

closes issue #122 