### PR TITLE
Add custom GUI for Move and RelativeMove transitions

### DIFF
--- a/unity/CAVE/Assets/Editor/CLI.cs
+++ b/unity/CAVE/Assets/Editor/CLI.cs
@@ -46,7 +46,7 @@ namespace Writing3D
                     XrRig = InstantiatedScene.scene.GetRootGameObjects()[0];
                     Root = InstantiatedScene.scene.GetRootGameObjects()[1];
                     GameObjects = new Dictionary<string, (GameObject, Xml.Object)>();
-                Walls = new Dictionary<string, Transform>() { { "Center", Root.transform } };
+                    Walls = new Dictionary<string, Transform>() { { "Center", Root.transform } };
 
                     // Testing - Instantiate the device simulator and set at top of hierarchy
                     if (!Application.isBatchMode)

--- a/unity/CAVE/Assets/Editor/CLI.cs
+++ b/unity/CAVE/Assets/Editor/CLI.cs
@@ -16,7 +16,7 @@ using static UnityEditor.Events.UnityEventTools;
 
 namespace Writing3D
 {
-    namespace Translation
+    namespace Editor
     {
         public static partial class CLI
         {

--- a/unity/CAVE/Assets/Editor/CLI.cs
+++ b/unity/CAVE/Assets/Editor/CLI.cs
@@ -26,6 +26,7 @@ namespace Writing3D
             private static GameObject Root;
             private static GameObject XrRig;
 
+            private static Dictionary<string, Transform> Walls;
             private static Dictionary<string, (GameObject, Xml.Object)> GameObjects;
 
             [MenuItem("Custom/CLI.Main %g")]
@@ -43,6 +44,7 @@ namespace Writing3D
                 XrRig = instantiatedScene.scene.GetRootGameObjects()[0];
                 Root = instantiatedScene.scene.GetRootGameObjects()[1];
                 GameObjects = new Dictionary<string, (GameObject, Xml.Object)>();
+                Walls = new Dictionary<string, Transform>() { { "Center", Root.transform } };
 
                 if (!UnityEditorInternal.InternalEditorUtility.inBatchMode)
                 {
@@ -190,15 +192,18 @@ namespace Writing3D
             // Create each <Placement> as an outlined GameObject 
             private static void BuildWalls()
             {
-                foreach (Xml.Placement xmlPlacement in XmlRoot.PlacementRoot)
+                foreach (Placement xmlPlacement in XmlRoot.PlacementRoot)
                 {
+                    string name = xmlPlacement.Name;
+
                     // Objects in the "Center" space are nested directly under Root
-                    if (xmlPlacement.Name == "Center") { continue; }
+                    if (name == "Center") { continue; }
 
                     // Create and position wall
                     GameObject wall = UnityEngine.Object.Instantiate(Resources.Load<GameObject>("Prefabs/wall"));
-                    wall.name = xmlPlacement.Name;
+                    wall.name = name;
                     SetTransform(wall.transform, xmlPlacement);
+                    Walls.Add(name, wall.transform);
                 }
             }
 

--- a/unity/CAVE/Assets/Editor/CLIEditor.cs
+++ b/unity/CAVE/Assets/Editor/CLIEditor.cs
@@ -3,15 +3,14 @@ using UnityEditor;
 
 namespace Writing3D
 {
-    namespace Translation
+    namespace Editor
     {
-        // Creates 
-        public class CLI_GUI : EditorWindow
+        public class CLIEditor : EditorWindow
         {
             [MenuItem("Custom/CLI Window")]
             private static void Init()
             {
-                EditorWindow window = GetWindow(typeof(CLI_GUI));
+                EditorWindow window = GetWindow(typeof(CLIEditor));
                 window.Show();
             }
 

--- a/unity/CAVE/Assets/Editor/CLIEditor.cs.meta
+++ b/unity/CAVE/Assets/Editor/CLIEditor.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e9b15ac0fec5a5141ac6868ff110f547
+guid: 7508090aee23afd409ca4a54cbc776fd
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/unity/CAVE/Assets/Editor/CLI_Helpers.cs
+++ b/unity/CAVE/Assets/Editor/CLI_Helpers.cs
@@ -57,13 +57,10 @@ namespace Writing3D
 
             /********** PLACEMENT ROOT    ***********/
 
-            // TODO: Refactor to use Walls?
             // Get the transform of the wall xmlPlacement is to be nested under
             private static Transform GetParent(Placement xmlPlacement)
             {
-                return xmlPlacement.RelativeTo == Placement.PlacementTypes.Center
-                        ? Root.transform // Nest under Root directly
-                        : Root.transform.Find(xmlPlacement.RelativeTo.ToString());
+                return Walls[xmlPlacement.RelativeTo.ToString()];
             }
 
             // Gets the converted position element from xmlPlacement

--- a/unity/CAVE/Assets/Editor/CLI_Helpers.cs
+++ b/unity/CAVE/Assets/Editor/CLI_Helpers.cs
@@ -279,9 +279,9 @@ namespace Writing3D
                 return xmlPlacement.RotationType switch
                 {
                     Placement.RotationTypes.Null => Move.RotationTypes.None,
-                    Placement.RotationTypes.Axis => Move.RotationTypes.Euler,
+                    Placement.RotationTypes.Axis => Move.RotationTypes.Rotation,
                     Placement.RotationTypes.LookAt => Move.RotationTypes.LookAt,
-                    Placement.RotationTypes.Normal => Move.RotationTypes.Euler,
+                    Placement.RotationTypes.Normal => Move.RotationTypes.Rotation,
                     _ => throw new Exception("Invalid rotation type")
                 };
             }
@@ -292,7 +292,7 @@ namespace Writing3D
                 return xmlPlacement.Rotation switch
                 {
                     Axis xmlAxis => CreateEuler(xmlAxis.RotationString, xmlAxis.Angle),
-                    LookAt xmlLookAt => new Move.LookAtRotation(
+                    LookAt xmlLookAt => new Move.LookAt(
                         ConvertVector3(xmlLookAt.TargetString),
                         ConvertVector3(xmlLookAt.UpString)
                     ),

--- a/unity/CAVE/Assets/Editor/CLI_Helpers.cs
+++ b/unity/CAVE/Assets/Editor/CLI_Helpers.cs
@@ -23,7 +23,7 @@ namespace Writing3D
             /********** Writing3D.Xml to Unity conversions    ***********/
 
             // Converts "[int], [int], [int]" to a UnityEngine.Color object
-            public static UnityEngine.Color ConvertColor(string colorString)
+            private static UnityEngine.Color ConvertColor(string colorString)
             {
                 string[] strings = colorString.Trim(new[] { ' ', '(', ')' }).Split(",");
                 return new UnityEngine.Color(
@@ -34,7 +34,7 @@ namespace Writing3D
             }
 
             // Converts a "([float], [float], [float])" string to a UnityEngine.Vector3 object
-            public static Vector3 ConvertVector3(string vectorString)
+            private static Vector3 ConvertVector3(string vectorString)
             {
                 string[] strings = vectorString.Trim(new[] { ' ', '(', ')' }).Split(",");
                 return new Vector3(
@@ -45,12 +45,12 @@ namespace Writing3D
             }
 
             // Converts a float to a UnityEngine.Vector3 object
-            public static Vector3 ConvertScale(float scale) { return Vector3.one * scale; }
+            private static Vector3 ConvertScale(float scale) { return Vector3.one * scale; }
 
             /********** Unity simple types    ***********/
 
             // Converts a "([float], [float], [float])" string and an angle to a Euler angle
-            public static Vector3 CreateEuler(string rotationString, float Angle)
+            private static Vector3 CreateEuler(string rotationString, float Angle)
             {
                 return ConvertVector3(rotationString) * Angle;
             }
@@ -64,7 +64,7 @@ namespace Writing3D
                 rotationType.LookAt: Rotate to look at target vector (world space)
                 rotationType.Normal: Local rotation around a normalized vector
             */
-            public static void SetTransform(Transform gameObjectT, Xml.Placement xmlPlacement, float scale = 1)
+            private static void SetTransform(Transform gameObjectT, Xml.Placement xmlPlacement, float scale = 1)
             {
                 gameObjectT.localScale = ConvertScale(scale);
                 gameObjectT.SetParent(GetParent(xmlPlacement), false);
@@ -96,50 +96,51 @@ namespace Writing3D
                 }
             }
 
-            public static Transform GetParent(Xml.Placement xmlPlacement)
+            private static Transform GetParent(Xml.Placement xmlPlacement)
             {
                 return xmlPlacement.RelativeTo == Xml.Placement.PlacementTypes.Center
                         ? Root.transform // Nest under Root directly
                         : Root.transform.Find(xmlPlacement.RelativeTo.ToString());
             }
 
-            public static Vector3 GetPosition(Xml.Placement xmlPlacement)
+            private static Vector3 GetPosition(Xml.Placement xmlPlacement)
             {
                 return ConvertVector3(xmlPlacement.PositionString);
             }
 
-            public static Placement GetPlacement(Xml.Placement xmlPlacement)
-            {
-                Placement placement = new(GetParent(xmlPlacement), GetPosition(xmlPlacement));
-                switch (xmlPlacement.Rotation)
-                {
-                    case Axis xmlAxis:
-                        placement.RotationType = Placement.Type.Euler;
-                        placement.EulerRotation =
-                            CreateEuler(xmlAxis.RotationString, xmlAxis.Angle);
-                        break;
-                    case LookAt xmlLookAt:
-                        placement.RotationType = Placement.Type.LookAt;
-                        placement.LookRotation = new Placement.LookAtRotation(
-                            ConvertVector3(xmlLookAt.TargetString),
-                            ConvertVector3(xmlLookAt.UpString)
-                        );
-                        break;
-                    case Normal xmlNormal:
-                        placement.RotationType = Placement.Type.Euler;
-                        placement.EulerRotation =
-                            CreateEuler(xmlNormal.NormalString, xmlNormal.Angle);
-                        break;
-                    default:
-                        placement.RotationType = Placement.Type.None;
-                        break;
-                }
-                return placement;
-            }
+            // private static 
+            // public static Placement GetPlacement(Xml.Placement xmlPlacement)
+            // {
+            //     Placement placement = new(GetParent(xmlPlacement), GetPosition(xmlPlacement));
+            //     switch (xmlPlacement.Rotation)
+            //     {
+            //         case Axis xmlAxis:
+            //             placement.RotationType = Placement.Type.Euler;
+            //             placement.EulerRotation =
+            //                 CreateEuler(xmlAxis.RotationString, xmlAxis.Angle);
+            //             break;
+            //         case LookAt xmlLookAt:
+            //             placement.RotationType = Placement.Type.LookAt;
+            //             placement.LookRotation = new Placement.LookAtRotation(
+            //                 ConvertVector3(xmlLookAt.TargetString),
+            //                 ConvertVector3(xmlLookAt.UpString)
+            //             );
+            //             break;
+            //         case Normal xmlNormal:
+            //             placement.RotationType = Placement.Type.Euler;
+            //             placement.EulerRotation =
+            //                 CreateEuler(xmlNormal.NormalString, xmlNormal.Angle);
+            //             break;
+            //         default:
+            //             placement.RotationType = Placement.Type.None;
+            //             break;
+            //     }
+            //     return placement;
+            // }
 
             /********** OBJECT ROOT    ***********/
 
-            public static GameObject CreateContent(Xml.Object xmlObject)
+            private static GameObject CreateContent(Xml.Object xmlObject)
             {
                 return xmlObject.Content.ContentData switch
                 {
@@ -153,7 +154,7 @@ namespace Writing3D
                 };
             }
 
-            public static GameObject CreateText(Text xmlText, string colorString)
+            private static GameObject CreateText(Text xmlText, string colorString)
             {
                 // Instantiate TextMeshPro or TextMeshProUGUI prefab
                 // TODO 64: Validate prefab settings
@@ -209,7 +210,7 @@ namespace Writing3D
 
             /********** ACTIONS    ***********/
 
-            public static void AddAction(LinkActions xmlLinkAction, LinkManager lm)
+            private static void AddAction(LinkActions xmlLinkAction, LinkManager lm)
             {
                 // Initialize action
                 LinkAction linkAction = CreateInstance<LinkAction>();
@@ -267,15 +268,21 @@ namespace Writing3D
                 );
             }
 
-            public static Transitions.Transition GetTransition(Xml.Transition xmlTransition, float duration)
+            private static Transitions.Transition GetTransition(Xml.Transition xmlTransition, float duration)
             {
                 return xmlTransition.Change switch
                 {
                     bool visible => CreateInstance<Visible>().Init(visible, duration),
-                    MovementTransition move => CreateInstance<Move>()
-                        .Init(GetPlacement(move.Placement), duration),
-                    MoveRel move => CreateInstance<RelativeMove>()
-                        .Init(GetPlacement(move.Placement), duration),
+                    // MovementTransition move => CreateInstance<Move>()
+                    //     .Init(
+                    //         // GetPlacement(move.Placement),
+                    //         GetParent(move.Placement),
+                    //         GetPosition(move.Placement),
+                            
+                    //         duration
+                    //     ),
+                    // MoveRel move => CreateInstance<RelativeMove>()
+                    //     .Init(GetPlacement(move.Placement), duration),
                     string color => CreateInstance<Transitions.Color>()
                         .Init(ConvertColor(color), duration),
                     float scale => CreateInstance<Scale>().Init(scale),

--- a/unity/CAVE/Assets/Editor/CLI_Helpers.cs
+++ b/unity/CAVE/Assets/Editor/CLI_Helpers.cs
@@ -16,7 +16,7 @@ using static UnityEditor.Events.UnityEventTools;
 
 namespace Writing3D
 {
-    namespace Translation
+    namespace Editor
     {
         public static partial class CLI
         {

--- a/unity/CAVE/Assets/Editor/MoveEditor.cs
+++ b/unity/CAVE/Assets/Editor/MoveEditor.cs
@@ -1,0 +1,53 @@
+using UnityEditor;
+
+using Writing3D.Transitions;
+
+namespace Writing3D
+{
+    namespace Editor
+    {
+        [CustomEditor(typeof(Move), true)]
+        public class MoveEditor : UnityEditor.Editor
+        {
+            private Move Move;
+
+            private void OnEnable()
+            {
+                Move = target as Move;
+            }
+
+            public override void OnInspectorGUI()
+            {
+                serializedObject.Update();
+
+                DrawPropertiesExcluding(
+                    serializedObject,
+                    "RotationType",
+                    "EulerRotation",
+                    "LookRotation"
+                );
+
+                EditorGUILayout.Space(); EditorGUILayout.Space();
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("RotationType"));
+
+                switch (Move.RotationType)
+                {
+                    case Move.RotationTypes.Euler:
+                        EditorGUILayout.PropertyField(
+                            serializedObject.FindProperty("EulerRotation")
+                        );
+                        break;
+                    case Move.RotationTypes.LookAt:
+                        EditorGUILayout.PropertyField(
+                            serializedObject.FindProperty("LookRotation")
+                        );
+                        break;
+                    case Move.RotationTypes.None:
+                    default:
+                        break;
+                }
+                serializedObject.ApplyModifiedProperties();
+            }
+        }
+    }
+}

--- a/unity/CAVE/Assets/Editor/MoveEditor.cs
+++ b/unity/CAVE/Assets/Editor/MoveEditor.cs
@@ -1,3 +1,4 @@
+using UnityEngine;
 using UnityEditor;
 
 using Writing3D.Transitions;

--- a/unity/CAVE/Assets/Editor/MoveEditor.cs
+++ b/unity/CAVE/Assets/Editor/MoveEditor.cs
@@ -23,7 +23,7 @@ namespace Writing3D
                 DrawPropertiesExcluding(
                     serializedObject,
                     "RotationType",
-                    "EulerRotation",
+                    "Rotation",
                     "LookRotation"
                 );
 
@@ -32,9 +32,9 @@ namespace Writing3D
 
                 switch (Move.RotationType)
                 {
-                    case Move.RotationTypes.Euler:
+                    case Move.RotationTypes.Rotation:
                         EditorGUILayout.PropertyField(
-                            serializedObject.FindProperty("EulerRotation")
+                            serializedObject.FindProperty("Rotation")
                         );
                         break;
                     case Move.RotationTypes.LookAt:

--- a/unity/CAVE/Assets/Editor/MoveEditor.cs
+++ b/unity/CAVE/Assets/Editor/MoveEditor.cs
@@ -10,11 +10,7 @@ namespace Writing3D
         public class MoveEditor : UnityEditor.Editor
         {
             private Move Move;
-
-            private void OnEnable()
-            {
-                Move = target as Move;
-            }
+            private void OnEnable() { Move = target as Move; }
 
             public override void OnInspectorGUI()
             {
@@ -26,12 +22,14 @@ namespace Writing3D
                     "Rotation",
                     "LookRotation"
                 );
-
                 EditorGUILayout.Space(); EditorGUILayout.Space();
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("RotationType"));
 
+                // Hide unused rotation type(s)
                 switch (Move.RotationType)
                 {
+                    case Move.RotationTypes.None:
+                        break;
                     case Move.RotationTypes.Rotation:
                         EditorGUILayout.PropertyField(
                             serializedObject.FindProperty("Rotation")
@@ -41,9 +39,6 @@ namespace Writing3D
                         EditorGUILayout.PropertyField(
                             serializedObject.FindProperty("LookRotation")
                         );
-                        break;
-                    case Move.RotationTypes.None:
-                    default:
                         break;
                 }
                 serializedObject.ApplyModifiedProperties();

--- a/unity/CAVE/Assets/Editor/MoveEditor.cs.meta
+++ b/unity/CAVE/Assets/Editor/MoveEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 02d69ecb7b850fb45b4bba04a49b6da2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity/CAVE/Assets/Resources/Scripts/ObjectManager.cs
+++ b/unity/CAVE/Assets/Resources/Scripts/ObjectManager.cs
@@ -34,14 +34,14 @@ namespace Writing3D
         {
             // Update parent
             // MoveTowards && RotateTowards in local space (parent space?)
-            Placement placement = (transition as Move)?.Placement;
-            Debug.Log($"RelativeMoveT {gameObject.name} {placement.Parent.name} {placement.Position}");
+            Move move = transition as Move;
+            Debug.Log($"RelativeMoveT {gameObject.name} {move.Parent.name} {move.Position}");
         }
 
         public void RelativeMoveTransition(Transition transition)
         {
-            Placement placement = (transition as RelativeMove)?.Placement;
-            Debug.Log($"RelativeMoveT {gameObject.name} {placement.Parent.name} {placement.Position}");
+            RelativeMove move = transition as RelativeMove;
+            Debug.Log($"RelativeMoveT {gameObject.name} {move.Parent.name} {move.Position}");
         }
 
         public void ColorTransition(Transition transition)

--- a/unity/CAVE/Assets/Resources/Scripts/SceneManager.cs
+++ b/unity/CAVE/Assets/Resources/Scripts/SceneManager.cs
@@ -1,5 +1,3 @@
-using System;
-
 using UnityEngine;
 
 namespace Writing3D
@@ -10,43 +8,6 @@ namespace Writing3D
         {
             // Quit when "ESC" is pressed
             if (Input.GetKeyDown(KeyCode.Escape)) { Application.Quit(); }
-        }
-    }
-
-    [Serializable]
-    public class Placement
-    {
-        // TODO 128: GUI should change Euler/Look Rotation based on Type
-        public Transform Parent;
-        public Vector3 Position;
-        public Type RotationType;
-        public Vector3 EulerRotation; // (Type.Euler)
-        public LookAtRotation LookRotation; //(Type.LookAt)        
-
-        public Placement(Transform parent, Vector3 position)
-        {
-            Parent = parent;
-            Position = position;
-        }
-
-        public enum Type
-        {
-            None,
-            Euler,
-            LookAt
-        }
-
-        [Serializable]
-        public class LookAtRotation
-        {
-            public Vector3 Target;
-            public Vector3 Up;
-
-            public LookAtRotation(Vector3 target, Vector3 up)
-            {
-                Target = target;
-                Up = up;
-            }
         }
     }
 }

--- a/unity/CAVE/Assets/Resources/Scripts/Transitions/Move.cs
+++ b/unity/CAVE/Assets/Resources/Scripts/Transitions/Move.cs
@@ -37,6 +37,7 @@ namespace Writing3D
                 switch (rotationType)
                 {
                     case RotationTypes.None:
+                        Rotation = Quaternion.identity;
                         break;
                     case RotationTypes.Rotation:
                         Rotation = Quaternion.Euler((Vector3)rotation);

--- a/unity/CAVE/Assets/Resources/Scripts/Transitions/Move.cs
+++ b/unity/CAVE/Assets/Resources/Scripts/Transitions/Move.cs
@@ -14,15 +14,12 @@ namespace Writing3D
         [Serializable]
         public class Move : Transition
         {
-            // public Placement Placement;
-
-            // TODO 128: GUI should change Euler/Look Rotation based on Type
             public Transform Parent;
             public Vector3 Position;
 
             public RotationTypes RotationType;
-            public Vector3 EulerRotation;
-            public LookAtRotation LookRotation;
+            public Quaternion Rotation;
+            public LookAt LookRotation;
 
             public Move Init(
                 Transform parent,
@@ -39,62 +36,33 @@ namespace Writing3D
 
                 switch (rotationType)
                 {
-                    case RotationTypes.Euler:
-                        EulerRotation = (Vector3)rotation;
+                    case RotationTypes.None:
+                        break;
+                    case RotationTypes.Rotation:
+                        Rotation = Quaternion.Euler((Vector3)rotation);
                         break;
                     case RotationTypes.LookAt:
-                        LookRotation = (LookAtRotation)rotation;
+                        LookRotation = (LookAt)rotation;
                         break;
-                    case RotationTypes.None:
-                    default:
-                        break;
+                    default: throw new Exception("Invalid rotation type");
                 }
                 return this;
             }
 
-            public Move Init(
-                Transform parent, Vector3 position,
-                // RotationTypes rotationType, Vector3 rotation
-                (RotationTypes, Vector3) rotation, float duration
-            )
-            {
-                Parent = parent;
-                Position = position;
-                RotationType = rotation.Item1;
-                EulerRotation = rotation.Item2;
-                Duration = duration;
-                return this;
-            }
-
-            public Move Init(
-                Transform parent, Vector3 position,
-                // RotationTypes rotationType, LookAtRotation rotation
-                (RotationTypes, LookAtRotation) rotation, float duration
-            )
-            {
-                Parent = parent;
-                Position = position;
-                RotationType = rotation.Item1;
-                LookRotation = rotation.Item2;
-                Duration = duration;
-                return this;
-            }
-
-            // TODO: Make enum nullable instead od None type (check)
             public enum RotationTypes
             {
                 None,
-                Euler,
+                Rotation,
                 LookAt
             }
 
             [Serializable]
-            public class LookAtRotation
+            public class LookAt
             {
                 public Vector3 Target;
                 public Vector3 Up;
 
-                public LookAtRotation(Vector3 target, Vector3 up)
+                public LookAt(Vector3 target, Vector3 up)
                 {
                     Target = target;
                     Up = up;

--- a/unity/CAVE/Assets/Resources/Scripts/Transitions/Move.cs
+++ b/unity/CAVE/Assets/Resources/Scripts/Transitions/Move.cs
@@ -14,7 +14,7 @@ namespace Writing3D
         [Serializable]
         public class Move : Transition
         {
-            public Placement Placement;
+            // public Placement Placement;
 
             // TODO 128: GUI should change Euler/Look Rotation based on Type
             public Transform Parent;
@@ -24,12 +24,12 @@ namespace Writing3D
             public Vector3 EulerRotation;
             public LookAtRotation LookRotation;
 
-            public Move Init(Placement placement, float duration)
-            {
-                Placement = placement;
-                Duration = duration;
-                return this;
-            }
+            // public Move Init(Placement placement, float duration)
+            // {
+            //     // Placement = placement;
+            //     Duration = duration;
+            //     return this;
+            // }
 
             public Move Init(
                 Transform parent, Vector3 position,
@@ -69,8 +69,6 @@ namespace Writing3D
             {
                 public Vector3 Target;
                 public Vector3 Up;
-
-                public LookAtRotation() { }
 
                 public LookAtRotation(Vector3 target, Vector3 up)
                 {

--- a/unity/CAVE/Assets/Resources/Scripts/Transitions/Move.cs
+++ b/unity/CAVE/Assets/Resources/Scripts/Transitions/Move.cs
@@ -16,11 +16,67 @@ namespace Writing3D
         {
             public Placement Placement;
 
+            // TODO 128: GUI should change Euler/Look Rotation based on Type
+            public Transform Parent;
+            public Vector3 Position;
+
+            public RotationTypes RotationType;
+            public Vector3 EulerRotation;
+            public LookAtRotation LookRotation;
+
             public Move Init(Placement placement, float duration)
             {
                 Placement = placement;
                 Duration = duration;
                 return this;
+            }
+
+            public Move Init(
+                Transform parent, Vector3 position,
+                RotationTypes rotationType, Vector3 rotation
+            )
+            {
+                Parent = parent;
+                Position = position;
+                RotationType = rotationType;
+                EulerRotation = rotation;
+                LookRotation = null;
+                return this;
+            }
+
+            public Move Init(
+                Transform parent, Vector3 position,
+                RotationTypes rotationType, LookAtRotation rotation
+            )
+            {
+                Parent = parent;
+                Position = position;
+                RotationType = rotationType;
+                LookRotation = rotation;
+                return this;
+            }
+
+            // TODO: Make enum nullable instead od None type (check)
+            public enum RotationTypes
+            {
+                None,
+                Euler,
+                LookAt
+            }
+
+            [Serializable]
+            public class LookAtRotation
+            {
+                public Vector3 Target;
+                public Vector3 Up;
+
+                public LookAtRotation() { }
+
+                public LookAtRotation(Vector3 target, Vector3 up)
+                {
+                    Target = target;
+                    Up = up;
+                }
             }
         }
     }

--- a/unity/CAVE/Assets/Resources/Scripts/Transitions/Move.cs
+++ b/unity/CAVE/Assets/Resources/Scripts/Transitions/Move.cs
@@ -24,35 +24,59 @@ namespace Writing3D
             public Vector3 EulerRotation;
             public LookAtRotation LookRotation;
 
-            // public Move Init(Placement placement, float duration)
-            // {
-            //     // Placement = placement;
-            //     Duration = duration;
-            //     return this;
-            // }
-
             public Move Init(
-                Transform parent, Vector3 position,
-                RotationTypes rotationType, Vector3 rotation
+                Transform parent,
+                Vector3 position,
+                RotationTypes rotationType,
+                object rotation,
+                float duration
             )
             {
                 Parent = parent;
                 Position = position;
                 RotationType = rotationType;
-                EulerRotation = rotation;
-                LookRotation = null;
+                Duration = duration;
+
+                switch (rotationType)
+                {
+                    case RotationTypes.Euler:
+                        EulerRotation = (Vector3)rotation;
+                        break;
+                    case RotationTypes.LookAt:
+                        LookRotation = (LookAtRotation)rotation;
+                        break;
+                    case RotationTypes.None:
+                    default:
+                        break;
+                }
                 return this;
             }
 
             public Move Init(
                 Transform parent, Vector3 position,
-                RotationTypes rotationType, LookAtRotation rotation
+                // RotationTypes rotationType, Vector3 rotation
+                (RotationTypes, Vector3) rotation, float duration
             )
             {
                 Parent = parent;
                 Position = position;
-                RotationType = rotationType;
-                LookRotation = rotation;
+                RotationType = rotation.Item1;
+                EulerRotation = rotation.Item2;
+                Duration = duration;
+                return this;
+            }
+
+            public Move Init(
+                Transform parent, Vector3 position,
+                // RotationTypes rotationType, LookAtRotation rotation
+                (RotationTypes, LookAtRotation) rotation, float duration
+            )
+            {
+                Parent = parent;
+                Position = position;
+                RotationType = rotation.Item1;
+                LookRotation = rotation.Item2;
+                Duration = duration;
                 return this;
             }
 


### PR DESCRIPTION
- Renames `Translation` namespace as `Editor` for files inside the Editor folder
- Adds a `Walls` dictionary to keep track of the different possibilities of `<RelativeTo>`
- Renames `CLI_GUI.cs` as `CLIEditor.cs`

`Transitions.Move` (and `Transitions.RelativeMove`) keep `Rotation` and `LookAt` in separate variables and use `RotationType` to return the correct value. Unfortunately if I use the `object` tag it won't show up in the GUI (Unity can't serialize the variable) so I have to do type the variables at compile time

closes #128