### PR TITLE
Ref python

### DIFF
--- a/schema/caveschema.xsd
+++ b/schema/caveschema.xsd
@@ -531,7 +531,7 @@
       <xs:attribute name="start-immediately" type="xs:boolean" default="true" />
     </xs:complexType>
   </xs:element>
-  
+
   <!-- <Sound> -->
   <xs:element name="Sound">
     <xs:complexType>
@@ -684,7 +684,13 @@
       </xs:sequence>
       <xs:attribute name="enabled" type="xs:boolean" default="true" />
       <xs:attribute name="name" type="xs:string" use="required" />
-      <xs:attribute name="duration" type="xs:double" default="0.0" />
+      <xs:attribute name="duration" default="0.0">
+        <xs:simpleType>
+          <xs:restriction base="xs:double">
+            <xs:minInclusive value="0.0" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
       <xs:attribute name="remain-enabled" type="xs:boolean" default="true" />
     </xs:complexType>
   </xs:element>
@@ -953,7 +959,13 @@
             </xs:choice>
             <xs:element name="Placement" type="PlacementType" />
           </xs:sequence>
-          <xs:attribute name="duration" type="xs:double" default="0.0" />
+          <xs:attribute name="duration" default="0.0">
+            <xs:simpleType>
+              <xs:restriction base="xs:double">
+                <xs:minInclusive value="0.0" />
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
         </xs:complexType>
       </xs:element>
       <xs:element name="Restart">
@@ -1011,7 +1023,13 @@
         </xs:complexType>
       </xs:element>
     </xs:choice>
-    <xs:attribute name="duration" type="xs:double" default="1.0" />
+    <xs:attribute name="duration" default="0.0">
+      <xs:simpleType>
+        <xs:restriction base="xs:double">
+          <xs:minInclusive value="0.0" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
   </xs:complexType>
   <xs:complexType name="ParticleDomainType">
     <xs:choice>

--- a/test/sample.xml
+++ b/test/sample.xml
@@ -44,7 +44,7 @@
                     <SelectedColor>255,0,0</SelectedColor>
                     <Actions>
                         <ObjectChange name="movingtext">
-                            <Transition duration="1.0">
+                            <Transition duration="-10.0">
                                 <Movement>
                                     <Placement>
                                         <RelativeTo>FrontWall</RelativeTo>

--- a/test/sample.xml
+++ b/test/sample.xml
@@ -44,7 +44,7 @@
                     <SelectedColor>255,0,0</SelectedColor>
                     <Actions>
                         <ObjectChange name="movingtext">
-                            <Transition duration="-10.0">
+                            <Transition duration="0.0">
                                 <Movement>
                                     <Placement>
                                         <RelativeTo>FrontWall</RelativeTo>

--- a/test/sample.xml
+++ b/test/sample.xml
@@ -44,7 +44,7 @@
                     <SelectedColor>255,0,0</SelectedColor>
                     <Actions>
                         <ObjectChange name="movingtext">
-                            <Transition duration="0.0">
+                            <Transition duration="1.0">
                                 <Movement>
                                     <Placement>
                                         <RelativeTo>FrontWall</RelativeTo>

--- a/unity/CAVE/Assets/Editor/CLI.cs
+++ b/unity/CAVE/Assets/Editor/CLI.cs
@@ -38,7 +38,6 @@ namespace Writing3D
                 {
                     Debug.Log($"Running Unity CLI at '{Application.dataPath}'");
 
-                    // The path to the xml file is sent as a command line argument
                     GetXmlPathArg();
                     LoadXml();
 
@@ -49,9 +48,9 @@ namespace Writing3D
                     Root = InstantiatedScene.scene.GetRootGameObjects()[1];
                     GameObjects = new Dictionary<string, (GameObject, Xml.Object)>();
 
+                    // Testing - Instantiate the device simulator and set at top of hierarchy
                     if (!Application.isBatchMode)
                     {
-                        // Testing - Instantiate the device simulator and set at top of hierarchy
                         UnityEngine.Object.Instantiate(
                             AssetDatabase.LoadAssetAtPath(
                                 "Assets/XR Interaction Toolkit/XR Device Simulator/" +

--- a/unity/CAVE/Assets/Editor/CLI.cs
+++ b/unity/CAVE/Assets/Editor/CLI.cs
@@ -84,10 +84,10 @@ namespace Writing3D
                     string[] args = Environment.GetCommandLineArgs();
                     for (int i = 0; i < args.Length; i++)
                     {
-                        // TODO: Validate --projectPath and --xmlPath to get xml
-                        Debug.Log(args[i]);
+                        // TODO: Validate --xmlPath to get xml
                         if (args[i] == "--xmlPath") { XmlPath = args[++i]; }
                     }
+                    Debug.Log("XML Path " + XmlPath);
                 }
                 catch (Exception)
                 {

--- a/unity/CAVE/Assets/Editor/CLI.cs
+++ b/unity/CAVE/Assets/Editor/CLI.cs
@@ -107,7 +107,7 @@ namespace Writing3D
                         if (args[i] == "--xmlPath") { XmlPath = args[++i]; }
                     }
                 }
-                catch (Exception)
+                catch
                 {
                     Debug.LogError("Error initializing command line arguments");
                     throw;
@@ -146,7 +146,7 @@ namespace Writing3D
                         $"Assets/Resources/Scenes/{Path.GetFileNameWithoutExtension(XmlPath)}.unity"
                     );
                 }
-                catch (Exception)
+                catch
                 {
                     Debug.LogError($"Unable to create scene for {XmlPath}");
                     throw;
@@ -281,7 +281,7 @@ namespace Writing3D
                     foreach (LinkActions xmlLinkAction in xmlLink.Actions)
                     {
                         try { AddAction(xmlLinkAction, lm); }
-                        catch (Exception)
+                        catch
                         {
                             Debug.LogError(
                                 "Unable to create action for " + xmlObject.Name +
@@ -307,7 +307,9 @@ namespace Writing3D
                 {
                     LogType.Log => "white",
                     LogType.Warning => "yellow",
-                    _ => "red",
+                    LogType.Error => "red",
+                    LogType.Exception => "bold red",
+                    _ => "white"
                 };
                 Console.WriteLine($"LOG:[{color}]{logString}[/{color}]");
             }

--- a/unity/CAVE/Assets/Editor/CLI.cs
+++ b/unity/CAVE/Assets/Editor/CLI.cs
@@ -6,7 +6,6 @@ using UnityEditor;
 using UnityEditor.SceneTemplate;
 using UnityEngine;
 using UnityEngine.SpatialTracking;
-using UnityEngine.UI;
 using UnityEngine.Events;
 using Unity.XR.CoreUtils;
 
@@ -33,7 +32,7 @@ namespace Writing3D
             public static void Main()
             {
                 Application.logMessageReceivedThreaded += HandleLog;
-                Debug.Log($"Running Unity CLI {ProjectPath}");
+                Debug.Log($"Running Unity CLI");
 
                 // The path to the xml file is sent as a command line argument
                 GetXmlPathArg();
@@ -72,7 +71,7 @@ namespace Writing3D
                 SetLinkActions();
 
                 // Save and quit
-                // EditorSceneManager.SaveScene(EditorSceneManager.GetActiveScene());
+                // EditorSceneManager.SaveScene(instantiatedScene.scene);
                 Application.logMessageReceivedThreaded -= HandleLog;
                 Application.Quit();
             }
@@ -85,6 +84,8 @@ namespace Writing3D
                     string[] args = Environment.GetCommandLineArgs();
                     for (int i = 0; i < args.Length; i++)
                     {
+                        // TODO: Validate --projectPath and --xmlPath to get xml
+                        Debug.Log(args[i]);
                         if (args[i] == "--projectPath") { ProjectPath = args[++i]; }
                     }
                 }

--- a/unity/CAVE/Assets/Editor/CLI.cs
+++ b/unity/CAVE/Assets/Editor/CLI.cs
@@ -20,7 +20,7 @@ namespace Writing3D
     {
         public static partial class CLI
         {
-            public static string ProjectPath;
+            public static string XmlPath;
 
             private static Root XmlRoot;
             private static GameObject Root;
@@ -86,7 +86,7 @@ namespace Writing3D
                     {
                         // TODO: Validate --projectPath and --xmlPath to get xml
                         Debug.Log(args[i]);
-                        if (args[i] == "--projectPath") { ProjectPath = args[++i]; }
+                        if (args[i] == "--xmlPath") { XmlPath = args[++i]; }
                     }
                 }
                 catch (Exception)
@@ -102,17 +102,17 @@ namespace Writing3D
                 try
                 {
                     System.Xml.Serialization.XmlSerializer serializer = new(typeof(Root));
-                    using var reader = System.Xml.XmlReader.Create(ProjectPath);
+                    using var reader = System.Xml.XmlReader.Create(XmlPath);
                     XmlRoot = (Root)serializer.Deserialize(reader);
                 }
                 catch (FileNotFoundException)
                 {
-                    Debug.LogError($"ERROR: File at {ProjectPath} not found");
+                    Debug.LogError($"ERROR: File at {XmlPath} not found");
                     throw;
                 }
                 catch
                 {
-                    Debug.LogError($"Error: Deserialization of file at {ProjectPath} failed.");
+                    Debug.LogError($"Error: Deserialization of file at {XmlPath} failed.");
                     throw;
                 }
             }
@@ -125,12 +125,12 @@ namespace Writing3D
                     return SceneTemplateService.Instantiate(
                         Resources.Load<SceneTemplateAsset>("CAVE"),
                         false,
-                        $"Assets/Resources/Scenes/{Path.GetFileNameWithoutExtension(ProjectPath)}.unity"
+                        $"Assets/Resources/Scenes/{Path.GetFileNameWithoutExtension(XmlPath)}.unity"
                     );
                 }
                 catch (Exception)
                 {
-                    Debug.LogError($"Error creating scene for {ProjectPath}");
+                    Debug.LogError($"Error creating scene for {XmlPath}");
                     throw;
                 }
             }

--- a/unity/CAVE/Assets/Editor/CLI.cs
+++ b/unity/CAVE/Assets/Editor/CLI.cs
@@ -36,8 +36,6 @@ namespace Writing3D
                 Application.logMessageReceivedThreaded += HandleLog;
                 try
                 {
-                    Debug.Log($"Running Unity CLI at '{Application.dataPath}'");
-
                     GetXmlPathArg();
                     LoadXml();
 

--- a/unity/CAVE/Assets/Editor/CLI.cs
+++ b/unity/CAVE/Assets/Editor/CLI.cs
@@ -36,7 +36,6 @@ namespace Writing3D
                 Application.logMessageReceivedThreaded += HandleLog;
                 try
                 {
-
                     Debug.Log($"Running Unity CLI at '{Application.dataPath}'");
 
                     // The path to the xml file is sent as a command line argument
@@ -82,7 +81,6 @@ namespace Writing3D
                     // Save and quit
                     EditorSceneManager.SaveScene(InstantiatedScene.scene);
                     Application.logMessageReceivedThreaded -= HandleLog;
-                    AssetDatabase.Refresh();
                     EditorApplication.Exit(0);
                 }
                 catch (Exception e)
@@ -91,7 +89,6 @@ namespace Writing3D
                     File.Delete(InstantiatedScene.scene.path);
                     Debug.LogException(e);
                     Application.logMessageReceivedThreaded -= HandleLog;
-                    AssetDatabase.Refresh();
                     EditorApplication.Exit(1);
                 }
             }

--- a/unity/CAVE/Assets/Editor/CLI_GUI.cs
+++ b/unity/CAVE/Assets/Editor/CLI_GUI.cs
@@ -17,9 +17,9 @@ namespace Writing3D
 
             private void OnGUI()
             {
-                if (CLI.ProjectPath is null) { CLI.ProjectPath = "../../test/sample.xml"; }
+                if (CLI.XmlPath is null) { CLI.XmlPath = "../../test/sample.xml"; }
 
-                CLI.ProjectPath = EditorGUILayout.TextField("Path: ", CLI.ProjectPath);
+                CLI.XmlPath = EditorGUILayout.TextField("Path: ", CLI.XmlPath);
 
                 if (GUILayout.Button("CLI.Main")) { CLI.Main(); }
                 Repaint();

--- a/unity/CAVE/Assets/Editor/CLI_Helpers.cs
+++ b/unity/CAVE/Assets/Editor/CLI_Helpers.cs
@@ -154,21 +154,18 @@ namespace Writing3D
                         tmpFont = TMP_FontAsset.CreateFontAsset(font);
                         tmpFont.name = Path.GetFileNameWithoutExtension(xmlText.Font);
                     }
-                    catch (NullReferenceException e)
+                    catch (NullReferenceException)
                     {
-                        Debug.LogError($"Error loading font: {xmlText.Font}");
-                        Debug.LogException(e);
+                        Debug.LogWarning($"Font {xmlText.Font} failed to load");
                     }
                 }
 
                 // Add font to the TextMeshPro object
                 try { tmpText.font = tmpFont; }
-                catch (NullReferenceException e)
+                catch (NullReferenceException)
                 {
-                    Debug.LogWarning($"{gameObject.name} {tmpFont} {tmpText.font}");
-                    Debug.LogError($"Error creating font asset {xmlText.Font} for {gameObject.name}");
-                    Debug.Log("Defaulting to fallback font LiberationSans SDF");
-                    Debug.LogException(e);
+                    Debug.LogWarning($"Error creating font asset {xmlText.Font} for {gameObject.name}");
+                    Debug.LogWarning("Defaulting to fallback font: LiberationSans SDF");
                 }
 
                 // Resize BoxCollider to the text

--- a/unity/CAVE/Assets/Editor/CLI_Helpers.cs
+++ b/unity/CAVE/Assets/Editor/CLI_Helpers.cs
@@ -140,6 +140,7 @@ namespace Writing3D
 
                 // Load font material
                 // TODO 72: More robust path checking
+                // TODO: Don't have to worry about re-throwing exceptions if handled in main
                 TMP_FontAsset tmpFont = Resources.Load<TMP_FontAsset>(
                     "Materials/Fonts/" +
                     Path.GetFileNameWithoutExtension(xmlText.Font) +

--- a/w3d_translator/errors.py
+++ b/w3d_translator/errors.py
@@ -22,6 +22,4 @@ class XmlError(Exception):
         return (
             f"{self.filename} does not match schema\n"
             + self.error
-            + "\n"
-            + f"Skipping {self.filename}\n"
         )

--- a/w3d_translator/errors.py
+++ b/w3d_translator/errors.py
@@ -19,7 +19,4 @@ class XmlError(Exception):
         super().__init__(f"{filename} does not conform to the defined schema")
 
     def __str__(self):
-        return (
-            f"{self.filename} does not match schema\n"
-            + self.error
-        )
+        return f"{self.filename} does not match schema\n" + self.error

--- a/w3d_translator/validate.py
+++ b/w3d_translator/validate.py
@@ -8,7 +8,6 @@ SCHEMA = etree.XMLSchema(file="schema/caveschema.xsd")
 
 # Validate directory
 def validate_project(dir: Path):
-
     # Path must be a directory
     if not dir.is_dir():
         raise ValidationError(f"Error: Project is not a directory: {dir}")

--- a/w3d_translator/w3d_translator.py
+++ b/w3d_translator/w3d_translator.py
@@ -143,7 +143,6 @@ def translate_file(unity_dir: Path, xml_path: Path):
 
     if sp.returncode != 0:
         # TODO: Make hyperlink to log file
-        console.print(xml_path)
         raise UnityError(
             "Translation failed. " + f"See '{logfile.name}'for more details."
         )

--- a/w3d_translator/w3d_translator.py
+++ b/w3d_translator/w3d_translator.py
@@ -104,8 +104,8 @@ def translate_file(unity_dir: Path, xml_path: Path):
             "-quit",
             "-logFile",
             "-",
-            "--projectPath",
-            f"{unity_dir}",
+            # "--projectPath",
+            # f"{unity_dir}",
             "--xmlPath",
             Path(*xml_path.parts[2:]),  # Path relative to unity_dir
             "-executeMethod",

--- a/w3d_translator/w3d_translator.py
+++ b/w3d_translator/w3d_translator.py
@@ -16,6 +16,8 @@ LOG_FLAG = "LOG:"  # Flag to send prints from the CLI script onto the console
 console = Console()
 err_console = Console(stderr=True, style="bold red")
 
+# TODO 137: Clean up rich colors (folder, file, warning, error, etc)
+
 
 # Opening message
 def greeting(in_dir: Path, out_dir: Path):
@@ -77,21 +79,17 @@ def copy_files(project_dir: Path, unity_dir: Path, unity_copy: Path):
 
 # Translate valid xml files (ignore invalid)
 def translate_files(unity_dir: Path, unity_copy: Path):
-    # TODO: Use a live progress group to keep track of the different files
-    # TODO: Launch each file in its own process
+    # TODO 138: Use a live progress group to keep track of the different files
+    # TODO 3: Launch each file in its own process
     all_good = True
     for xml_path in unity_copy.rglob("*.xml"):
         console.print(f"Translating file: '{xml_path.name}'")
         try:
-            validate_xml(xml_path)
-            console.print(f"'{xml_path.name}' is valid")
             translate_file(unity_dir, xml_path)
         except (XmlError, UnityError) as e:
             err_console.print(e)
             all_good = False
-            # TODO: Delete scene file if translated with errors
 
-    # TODO 54, 55: Change message if some files aren't translated correctly
     if all_good:
         console.print(
             ":white_check_mark: "
@@ -106,11 +104,11 @@ def translate_files(unity_dir: Path, unity_copy: Path):
 
 
 # Translate an XML file using Unity's CLI
-# TODO: Return bool for if it ran correctly, change print in translate_files
 def translate_file(unity_dir: Path, xml_path: Path):
-    # TODO: Change rich print type to see latest status
-    # TODO: Catch Errors
-    # Try to run, catch error
+    validate_xml(xml_path)
+    console.print(f"'{xml_path.name}' is valid")
+
+    # Run Unity CLI
     with Popen(
         [
             f"{UNITY_PATH}",
@@ -142,7 +140,7 @@ def translate_file(unity_dir: Path, xml_path: Path):
                 logfile.write(line)
 
     if sp.returncode != 0:
-        # TODO: Make hyperlink to log file
+        # TODO: Make hyperlink
         raise UnityError(
             "Translation failed. " + f"See '{logfile.name}'for more details."
         )

--- a/w3d_translator/w3d_translator.py
+++ b/w3d_translator/w3d_translator.py
@@ -97,6 +97,7 @@ def translate_files(unity_dir: Path, unity_copy: Path):
 
 # Translate an XML file using Unity's CLI
 def translate_file(unity_dir: Path, xml_path: Path):
+    # TODO: Catch Errors
     with Popen(
         [
             f"{UNITY_PATH}",
@@ -104,9 +105,11 @@ def translate_file(unity_dir: Path, xml_path: Path):
             "-quit",
             "-logFile",
             "-",
-            # "--projectPath",
-            # f"{unity_dir}",
             "--xmlPath",
+            # TODO: Fix xml path
+            # TODO: Unity still thinks it's in the old folder? For the full path?
+            # Currently "C:\Users\Rob\ROOT\CCV\W3D Translator\unity\CAVE\Assets\Resources\Original Project\everything.xml" # noqa
+            # Need "C:\Users\Rob\ROOT\CCV\W3D Translator\[out]\Assets\Resources\Original Project\everything.xml" # noqa
             Path(*xml_path.parts[2:]),  # Path relative to unity_dir
             "-executeMethod",
             "Writing3D.Translation.CLI.Main"

--- a/w3d_translator/w3d_translator.py
+++ b/w3d_translator/w3d_translator.py
@@ -129,7 +129,9 @@ def translate_file(unity_dir: Path, xml_path: Path):
         bufsize=1,
     ) as sp, open(
         Path(unity_dir, "Logs", f"cli_{xml_path.stem}.log"), "w"
-    ) as logfile:
+    ) as logfile, console.status(
+        "Running Unity CLI"
+    ):
         # Process stdout and stderr as it's written to
         for line in sp.stdout:
             if line.startswith(LOG_FLAG):
@@ -140,7 +142,7 @@ def translate_file(unity_dir: Path, xml_path: Path):
                 logfile.write(line)
 
     if sp.returncode != 0:
-        # TODO: Make hyperlink
+        # TODO 139: Make hyperlink
         raise UnityError(
             "Translation failed. " + f"See '{logfile.name}'for more details."
         )

--- a/w3d_translator/w3d_translator.py
+++ b/w3d_translator/w3d_translator.py
@@ -76,10 +76,7 @@ def copy_files(project_dir: Path, unity_dir: Path, unity_copy: Path):
 def translate_files(unity_dir: Path, unity_copy: Path):
     try:
         for xml_path in unity_copy.rglob("*.xml"):
-            with console.status(
-                "Translating file: "
-                + f"[cyan]{unity_copy.name}/{xml_path.name}[/cyan]"
-            ):
+            with console.status(f"Translating file: '{xml_path.name}'"):
                 try:
                     validate_xml(xml_path)
                 except XmlError as e:
@@ -105,15 +102,14 @@ def translate_file(unity_dir: Path, xml_path: Path):
             f"{UNITY_PATH}",
             "-batchmode",
             "-quit",
-            "-projectPath",
-            f"{unity_dir}",
             "-logFile",
             "-",
-            "-executeMethod",
-            # "CLI.Main",
-            "Writing3D.Translation.CLI.Main"
+            "--projectPath",
+            f"{unity_dir}",
             "--xmlPath",
             Path(*xml_path.parts[2:]),  # Path relative to unity_dir
+            "-executeMethod",
+            "Writing3D.Translation.CLI.Main"
         ],
         bufsize=1,
         stdout=PIPE,


### PR DESCRIPTION
Fixes the communication between Python and Unity and cleans up the logging

- xsd now asserts that `duration` attributes are >= 0
- Wraps `CLI.Main` in a try/catch block to prevent Unity from crashing
- Adds Logging throughout the Unity translation
- Unity scene is deleted if an exception occurred during translation
- Renames `ProjectPath` as `XmlPath`